### PR TITLE
Migrate to arduino-check dependency workflow argument

### DIFF
--- a/.github/workflows/arduino_quality_check.yml
+++ b/.github/workflows/arduino_quality_check.yml
@@ -13,4 +13,5 @@ jobs:
     uses: sensirion/.github/.github/workflows/driver.arduino.check.yml@main
     with:
       expect-arduino-examples: true
+      dependency-list: '[{"name": "Sensirion Core"}, {"source-path": "./"}, {"name": "Sensirion I2C SHT4x"}]'
       lint-lib-manager-check: update

--- a/examples/exampleUsageFrc/.arduino-ci.yml
+++ b/examples/exampleUsageFrc/.arduino-ci.yml
@@ -1,3 +1,0 @@
-compile:
-  libraries:
-    - "Sensirion I2C SHT4x"

--- a/examples/measurementWithCompensation/.arduino-ci.yml
+++ b/examples/measurementWithCompensation/.arduino-ci.yml
@@ -1,3 +1,0 @@
-compile:
-  libraries:
-    - "Sensirion I2C SHT4x"


### PR DESCRIPTION
The examples requiring the additional `Sensirion I2C SHT4x` dependency were defining it in `.arduino-ci.yml`. The file is no longer supported, and thus the dependency is ignored. This migrates to the workflow dependencies argument instead. 